### PR TITLE
[feat] check client by authme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2440,7 +2440,6 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "express": "^5.1.0",
     "express-async-handler": "^1.2.0",
     "express-session": "^1.18.1",
+    "jsonwebtoken": "^9.0.2",
     "mysql2": "^3.14.2",
     "reflect-metadata": "^0.2.2",
     "typeorm": "^0.3.25"

--- a/src/controllers/member-controller.ts
+++ b/src/controllers/member-controller.ts
@@ -59,6 +59,13 @@ export const discordCallback = asyncHandler(async (req: Request, res: Response) 
     }
 });
 
+export const authMe = (req: Request, res: Response) => {
+    if(req.member)  {
+        res.status(200).send(" 요청한 클라이언트 정보 : " + req.member);
+        res.json({ member : req.member });
+    }
+}
+
 // // AccessToken 만료시 RefreshToken과 함께 재발급
 // export const refreshTokens = async (req: Request, res: Response) => {
 //     const accessToken = req.cookies.accessToken;

--- a/src/router/auth-router.ts
+++ b/src/router/auth-router.ts
@@ -1,10 +1,13 @@
 import express, { Request, Response } from "express";
-import {discordCallback, discordLogin } from "../controllers/member-controller";
+import {authMe, discordCallback, discordLogin} from "../controllers/member-controller";
+import {authenticateToken} from "../middlewares/authenticate-token";
 
 const router = express.Router();
 
 router.get('/discord', discordLogin);
 
 router.get('/discord/callback', discordCallback);
+
+router.get('/auth/me', authenticateToken, authMe);
 
 export default router;


### PR DESCRIPTION
1. header에서 auth/me라는 경로로 토큰을 이용해 멤버 정보를 제공(front에서 로그인 유무에 따른 header 렌더링을 위함)