### PR TITLE
[fix] 디스코드 로그인 중단 시 메인페이지로 리디렉션

### DIFF
--- a/src/controllers/member-controller.ts
+++ b/src/controllers/member-controller.ts
@@ -25,7 +25,7 @@ export const discordCallback = asyncHandler(async (req: Request, res: Response) 
     const code = req.query.code as string | undefined;
 
     if(!code)   {
-        res.status(400).send("코드가 없습니다.");
+        res.redirect(process.env.BASE_URL!);
         return;
     }
     

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -95,6 +95,10 @@ export const generateNewTokens = async (refreshToken: string) => {
         const member: MemberInfo = verifyRefreshToken(refreshToken);
 
         const redisToken = await getRefreshTokenInRedis(member.id);
+
+        console.log("refreshToken in Client : ", refreshToken);
+        console.log("refreshToken in Redis : ", redisToken);
+
         if (redisToken !== refreshToken) {
             // 일치하지 않으면 예외 발생
             throw new Error("Refresh Token이 유효하지 않습니다.");


### PR DESCRIPTION
1. 어세스토큰 사용다하면 리프레시 토큰이 어세스 토큰을 재발급 안해주는거같음
A1 : Test 해보니까 재발급 해줌, 아무래도 Redis에 있는 refresh 토큰이랑 Client가 주는 refresh 토큰 값이랑 달라서 에러 발생하는거 같음 추후 같은 문제 계속 발생하면 함 알아봄

2. 디스코드 로그인 창에서 취소 누르면 화면 없음
A2 : discordCallback에서 도중에 로그인 취소 했을때 로직 수정함(현재는 메인페이지로 돌아감)

3. 로그아웃하면 http://localhost:3000/undefined 해당 페이지로 다시 전이랑 똑같이뜸
A3 : Test 해보니까 로그아웃대고, 메인 페이지로 돌아가짐!